### PR TITLE
[VIDEO-3085] Add extra event forwarding to intersink element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,8 +2982,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -3008,8 +3008,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-allocators"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3020,8 +3020,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-allocators-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3032,8 +3032,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-app"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3046,8 +3046,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-app-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gstreamer-base-sys",
@@ -3058,8 +3058,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "cfg-if",
  "glib",
@@ -3074,8 +3074,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3087,8 +3087,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "atomic_refcell",
  "cfg-if",
@@ -3100,8 +3100,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3112,8 +3112,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-check"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3122,8 +3122,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-check-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3134,8 +3134,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3148,8 +3148,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-egl"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3160,8 +3160,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-egl-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gstreamer-gl-sys",
@@ -3171,8 +3171,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3185,8 +3185,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-wayland"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3197,8 +3197,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-wayland-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gstreamer-gl-sys",
@@ -3208,8 +3208,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-x11"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3220,8 +3220,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-x11-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gstreamer-gl-sys",
@@ -3231,8 +3231,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-net"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "gio",
  "glib",
@@ -3242,8 +3242,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-net-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -3254,8 +3254,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-pbutils"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3268,8 +3268,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-pbutils-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3282,8 +3282,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-rtp"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3293,8 +3293,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-rtp-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gstreamer-base-sys",
@@ -3305,8 +3305,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sdp"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3315,8 +3315,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sdp-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gstreamer-sys",
@@ -3326,8 +3326,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3337,8 +3337,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-utils"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "gstreamer",
  "gstreamer-app",
@@ -3349,8 +3349,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -3366,8 +3366,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3379,8 +3379,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib",
  "gstreamer",
@@ -3391,8 +3391,8 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-webrtc-sys"
-version = "0.22.7"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=0.22#a9f94b90888b19091dcbdec07cad4c2231e80bfe"
+version = "0.22.8"
+source = "git+https://github.com/blinemedical/gstreamer-rs?rev=ae8af3f#ae8af3f45821632797cebe293258b90550081db1"
 dependencies = [
  "glib-sys",
  "gstreamer-sdp-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,21 +129,21 @@ gtk = { package = "gtk4", git = "https://github.com/gtk-rs/gtk4-rs", branch = "0
 gdk-wayland = { package = "gdk4-wayland", git = "https://github.com/gtk-rs/gtk4-rs", branch = "0.8", version = "0.8"}
 gdk-x11 = { package = "gdk4-x11", git = "https://github.com/gtk-rs/gtk4-rs", branch = "0.8", version = "0.8"}
 gdk-win32 = { package = "gdk4-win32", git = "https://github.com/gtk-rs/gtk4-rs", branch = "0.8", version = "0.8"}
-gst = { package = "gstreamer", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-allocators = { package = "gstreamer-allocators", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-app = { package = "gstreamer-app", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-audio = { package = "gstreamer-audio", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-base = { package = "gstreamer-base", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-check = { package = "gstreamer-check", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-gl = { package = "gstreamer-gl", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-gl-egl = { package = "gstreamer-gl-egl", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-gl-wayland = { package = "gstreamer-gl-wayland", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-gl-x11 = { package = "gstreamer-gl-x11", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-net = { package = "gstreamer-net", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-pbutils = { package = "gstreamer-pbutils", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
+gst = { package = "gstreamer", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-allocators = { package = "gstreamer-allocators", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-app = { package = "gstreamer-app", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-audio = { package = "gstreamer-audio", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-base = { package = "gstreamer-base", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-check = { package = "gstreamer-check", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-gl = { package = "gstreamer-gl", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-gl-egl = { package = "gstreamer-gl-egl", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-gl-wayland = { package = "gstreamer-gl-wayland", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-gl-x11 = { package = "gstreamer-gl-x11", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-net = { package = "gstreamer-net", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-pbutils = { package = "gstreamer-pbutils", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
 gst-plugin-version-helper = { path="./version-helper", version = "0.8" }
-gst-rtp = { package = "gstreamer-rtp", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-sdp = { package = "gstreamer-sdp", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-utils = { package = "gstreamer-utils", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-video = { package = "gstreamer-video", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
-gst-webrtc = { package = "gstreamer-webrtc", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.22", version = "0.22" }
+gst-rtp = { package = "gstreamer-rtp", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-sdp = { package = "gstreamer-sdp", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-utils = { package = "gstreamer-utils", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-video = { package = "gstreamer-video", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }
+gst-webrtc = { package = "gstreamer-webrtc", git = "https://github.com/blinemedical/gstreamer-rs", rev = "ae8af3f" }

--- a/generic/inter/src/sink/imp.rs
+++ b/generic/inter/src/sink/imp.rs
@@ -148,10 +148,7 @@ impl ObjectImpl for InterSink {
                     .get::<gst::Array>()
                     .expect("type checked upstream")
                     .iter()
-                    .map(|v| {
-                        let t = v.get::<gst::EventType>().expect("type checked upstream");
-                        gst::EventType::from(t)
-                    })
+                    .map(|v| v.get::<gst::EventType>().expect("type checked upstream"))
                     .collect::<Vec<_>>();
                 settings.event_types = types;
             }
@@ -167,9 +164,10 @@ impl ObjectImpl for InterSink {
             }
             "event-types" => {
                 let settings = self.settings.lock().unwrap();
-                settings.event_types
+                settings
+                    .event_types
                     .iter()
-                    .map(|x| gst::EventType::from(*x).to_send_value())
+                    .map(|x| x.to_send_value())
                     .collect::<gst::Array>()
                     .to_value()
             }

--- a/generic/inter/src/sink/imp.rs
+++ b/generic/inter/src/sink/imp.rs
@@ -22,7 +22,7 @@ impl Default for Settings {
     fn default() -> Self {
         Settings {
             producer_name: DEFAULT_PRODUCER_NAME.to_string(),
-            event_types: Vec::default(),
+            event_types: vec![gst::EventType::Eos],
         }
     }
 }
@@ -45,9 +45,7 @@ impl InterSink {
 
         match InterStreamProducer::acquire(&settings.producer_name, &state.appsink) {
             Ok(producer) => {
-                if !settings.event_types.is_empty() {
-                    producer.set_forward_events(settings.event_types.clone());
-                }
+                producer.set_forward_events(settings.event_types.clone());
                 Ok(())
             }
             Err(err) => Err(err),
@@ -102,14 +100,14 @@ impl ObjectImpl for InterSink {
                     .element_spec(
                         &glib::ParamSpecEnum::builder_with_default(
                             "event-type",
-                            gst::EventType::CustomDownstream,
+                            gst::EventType::Eos,
                         )
                         .nick("Event Type")
                         .blurb("Event Type")
                         .build(),
                     )
                     .nick("Forwarded Event Types")
-                    .blurb("Forwarded Event Types (default None)")
+                    .blurb("Forwarded Event Types (default Eos)")
                     .mutable_ready()
                     .build(),
             ]

--- a/generic/inter/src/sink/imp.rs
+++ b/generic/inter/src/sink/imp.rs
@@ -22,7 +22,7 @@ impl Default for Settings {
     fn default() -> Self {
         Settings {
             producer_name: DEFAULT_PRODUCER_NAME.to_string(),
-            event_types: vec![gst::EventType::Eos],
+            event_types: Vec::default(),
         }
     }
 }
@@ -45,7 +45,9 @@ impl InterSink {
 
         match InterStreamProducer::acquire(&settings.producer_name, &state.appsink) {
             Ok(producer) => {
-                producer.set_forward_events(settings.event_types.clone());
+                if !settings.event_types.is_empty() {
+                    producer.set_forward_events(settings.event_types.clone());
+                }
                 Ok(())
             }
             Err(err) => Err(err),
@@ -98,13 +100,16 @@ impl ObjectImpl for InterSink {
                     .build(),
                 gst::ParamSpecArray::builder("event-types")
                     .element_spec(
-                        &glib::ParamSpecEnum::builder_with_default("event-type", gst::EventType::Eos)
-                            .nick("Event Type")
-                            .blurb("Event Type")
-                            .build(),
+                        &glib::ParamSpecEnum::builder_with_default(
+                            "event-type",
+                            gst::EventType::CustomDownstream,
+                        )
+                        .nick("Event Type")
+                        .blurb("Event Type")
+                        .build(),
                     )
                     .nick("Forwarded Event Types")
-                    .blurb("Forward Event Types (default EOS)")
+                    .blurb("Forwarded Event Types (default None)")
                     .mutable_ready()
                     .build(),
             ]

--- a/generic/inter/src/sink/imp.rs
+++ b/generic/inter/src/sink/imp.rs
@@ -15,12 +15,14 @@ const DEFAULT_PRODUCER_NAME: &str = "default";
 #[derive(Debug)]
 struct Settings {
     producer_name: String,
+    event_types: Vec<gst::EventType>,
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Settings {
             producer_name: DEFAULT_PRODUCER_NAME.to_string(),
+            event_types: vec![gst::EventType::Eos],
         }
     }
 }
@@ -41,9 +43,13 @@ impl InterSink {
         let settings = self.settings.lock().unwrap();
         let state = self.state.lock().unwrap();
 
-        InterStreamProducer::acquire(&settings.producer_name, &state.appsink)?;
-
-        Ok(())
+        match InterStreamProducer::acquire(&settings.producer_name, &state.appsink) {
+            Ok(producer) => {
+                producer.set_forward_events(settings.event_types.clone());
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     fn unprepare(&self) {
@@ -83,12 +89,25 @@ impl ObjectSubclass for InterSink {
 impl ObjectImpl for InterSink {
     fn properties() -> &'static [glib::ParamSpec] {
         static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
-            vec![glib::ParamSpecString::builder("producer-name")
-                .nick("Producer Name")
-                .blurb("Producer Name to use")
-                .doc_show_default()
-                .mutable_playing()
-                .build()]
+            vec![
+                glib::ParamSpecString::builder("producer-name")
+                    .nick("Producer Name")
+                    .blurb("Producer Name to use")
+                    .doc_show_default()
+                    .mutable_playing()
+                    .build(),
+                gst::ParamSpecArray::builder("event-types")
+                    .element_spec(
+                        &glib::ParamSpecEnum::builder_with_default("event-type", gst::EventType::Eos)
+                            .nick("Event Type")
+                            .blurb("Event Type")
+                            .build(),
+                    )
+                    .nick("Forwarded Event Types")
+                    .blurb("Forward Event Types (default EOS)")
+                    .mutable_ready()
+                    .build(),
+            ]
         });
 
         PROPERTIES.as_ref()
@@ -123,6 +142,19 @@ impl ObjectImpl for InterSink {
                     }
                 }
             }
+            "event-types" => {
+                let mut settings = self.settings.lock().unwrap();
+                let types = value
+                    .get::<gst::Array>()
+                    .expect("type checked upstream")
+                    .iter()
+                    .map(|v| {
+                        let t = v.get::<gst::EventType>().expect("type checked upstream");
+                        gst::EventType::from(t)
+                    })
+                    .collect::<Vec<_>>();
+                settings.event_types = types;
+            }
             _ => unimplemented!(),
         };
     }
@@ -132,6 +164,14 @@ impl ObjectImpl for InterSink {
             "producer-name" => {
                 let settings = self.settings.lock().unwrap();
                 settings.producer_name.to_value()
+            }
+            "event-types" => {
+                let settings = self.settings.lock().unwrap();
+                settings.event_types
+                    .iter()
+                    .map(|x| gst::EventType::from(*x).to_send_value())
+                    .collect::<gst::Array>()
+                    .to_value()
             }
             _ => unimplemented!(),
         }

--- a/generic/inter/tests/inter.rs
+++ b/generic/inter/tests/inter.rs
@@ -136,3 +136,49 @@ fn test_change_producer_name() {
     element1.set_state(gst::State::Null).unwrap();
     element2.set_state(gst::State::Null).unwrap();
 }
+
+#[test]
+#[serial]
+fn test_event_forwarding() {
+    init();
+
+    let mut hc = start_consumer("p");
+    let (srcpad, intersink) = start_producer("p");
+
+    intersink.set_state(gst::State::Null).unwrap();
+    intersink.set_property(
+        "event-types",
+        gst::Array::new(vec![gst::EventType::Eos, gst::EventType::CustomDownstream]),
+    );
+    intersink.set_state(gst::State::Playing).unwrap();
+
+    push_one(&srcpad, gst::ClockTime::from_nseconds(1));
+
+    let s = gst::Structure::builder("MyEvent")
+        .field("unsigned", 100u64)
+        .build();
+    assert!(srcpad.push_event(gst::event::CustomDownstream::new(s)));
+    assert!(srcpad.push_event(gst::event::Eos::new()));
+
+    let mut found = false;
+    loop {
+        use gst::EventView;
+
+        if let Ok(event) = hc.pull_event() {
+            match event.view() {
+                EventView::CustomDownstream(e) => {
+                    let v = e.structure().unwrap().get::<u64>("unsigned");
+                    assert!(v.is_ok_and(|v| v == 100u64));
+                    found = true;
+                    break;
+                }
+                EventView::Eos(..) => {
+                    break;
+                }
+                _ => (),
+            };
+        }
+    }
+    intersink.set_state(gst::State::Null).unwrap();
+    assert!(found);
+}


### PR DESCRIPTION
## Description

1. Adds `event-type`, a list of GstEvent types, that the `intersink`'s underlying StreamProducer will forward to consumers (`intersrc`).
2. Updates `Cargo.toml` to point at LLDC's `gstreamer-rs` version >0.22.8 rev `ae8af3f`, which includes a fix to permit reading the current list of forwarded event types from the StreamProducer when the `intersink` element prepares to stream.

## Testing

The `tests/inter.rs` suite has been updated to include `test_event_forwarding()`.

One thing of note is that the custom serialized event in that test only is passed if a buffer is pushed *first*.  When I stated this finding to the maintainer, they expressed concern that it shouldn't behave like that and requested further investigation, trying again against `main`, etc.  However, in our use case, this is not a problem since the pipeline will pre-roll and stream long before we start pushing custom events down the `intersink`.