### PR TITLE
[VIDEO-3092] (Resurrected) Backport awss3sink softseek from upstream PR

### DIFF
--- a/net/aws/src/s3sink/multipartsink.rs
+++ b/net/aws/src/s3sink/multipartsink.rs
@@ -1326,7 +1326,9 @@ impl ObjectImpl for S3Sink {
                     .build(),
                 glib::ParamSpecInt64::builder("num-cached-parts")
                     .nick("Number of parts to cache (seeking)")
-                    .blurb("Number of parts to cache to enable seeking before the multipart upload completes")
+                    .blurb(
+                        "Number of parts to cache to enable seeking before the multipart upload completes.  \
+                         A positive number caches from the start of the stream; a negative number caches from the end.")
                     .minimum(-1 * MAX_MULTIPART_NUMBER)
                     .maximum(MAX_MULTIPART_NUMBER)
                     .default_value(DEFAULT_NUM_CACHED_PARTS)

--- a/net/aws/src/s3sink/multipartsink.rs
+++ b/net/aws/src/s3sink/multipartsink.rs
@@ -256,22 +256,21 @@ impl UploaderPartCache {
      * be filled with a copy.
      */
     pub fn find(&self, offset: u64) -> Result<(&PartInfo, u16), gst::ErrorMessage> {
-        let mut i = 1;
         let mut start = 0_u64;
 
-        for item in self.cache.iter() {
+        for (i, item) in self.cache.iter().enumerate() {
             let item_size: u64 = item.data_size.try_into().unwrap();
             let range = start..start + item_size;
+            let part_num = (i+1) as u16;
 
             if range.contains(&offset) {
-                return Ok((self.get(i).unwrap(), i));
+                return Ok((self.get(part_num).unwrap(), part_num));
             }
-            i += 1;
             start += item_size;
         }
         return Err(gst::error_msg!(
             gst::ResourceError::NotFound,
-            ["Could not find part {i} in cache"]
+            ["Could not find part for offset {offset} in cache"]
         ));
     }
 }

--- a/net/aws/src/s3sink/multipartsink.rs
+++ b/net/aws/src/s3sink/multipartsink.rs
@@ -53,6 +53,9 @@ const DEFAULT_UPLOAD_PART_RETRY_DURATION_MSEC: u64 = 60_000;
 const DEFAULT_COMPLETE_REQUEST_TIMEOUT_MSEC: u64 = 600_000; // 10 minutes
 const DEFAULT_COMPLETE_RETRY_DURATION_MSEC: u64 = 3_600_000; // 60 minutes
 
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+const MAX_MULTIPART_NUMBER: i64 = 10000;
+
 struct Started {
     client: Client,
     buffer: Vec<u8>,
@@ -73,9 +76,6 @@ impl Started {
     }
 
     pub fn increment_part_number(&mut self) -> Result<i64, gst::ErrorMessage> {
-        // https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
-        const MAX_MULTIPART_NUMBER: i64 = 10000;
-
         if self.part_number > MAX_MULTIPART_NUMBER {
             return Err(gst::error_msg!(
                 gst::ResourceError::Failed,

--- a/net/aws/tests/s3.rs
+++ b/net/aws/tests/s3.rs
@@ -55,15 +55,24 @@ mod tests {
             .unwrap();
     }
 
-    // Common helper
-    async fn do_s3_multipart_test(key_prefix: &str) {
-        init();
-
+    fn get_env_args(key_prefix: &str) -> (String, String, String) {
         let region = std::env::var("AWS_REGION").unwrap_or_else(|_| DEFAULT_S3_REGION.to_string());
         let bucket =
             std::env::var("AWS_S3_BUCKET").unwrap_or_else(|_| "gst-plugins-rs-tests".to_string());
         let key = format!("{key_prefix}-{:?}.txt", chrono::Utc::now());
-        let uri = format!("s3://{region}/{bucket}/{key}");
+        (region, bucket, key)
+    }
+
+    fn get_uri(region: &str, bucket: &str, key: &str) -> String {
+        format!("s3://{region}/{bucket}/{key}")
+    }
+
+    // Common helper
+    async fn do_s3_multipart_test(key_prefix: &str) {
+        init();
+
+        let (region, bucket, key) = get_env_args(key_prefix);
+        let uri = get_uri(&region, &bucket, &key);
         let content = "Hello, world!\n".as_bytes();
 
         // Manually add the element so we can configure it before it goes to PLAYING


### PR DESCRIPTION
## Description

This PR takes the state of the [pull request's](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/1641) version and ports it to 0.12 for us to use in our 1.24.x build.

Tests are included for both the cache system and integration tests against S3, however you will need to re-enable all of the tests by removing the disabling decoration and then exporting various AWS variables into the environment so the tests can execute.  One such way is via the `.vscode/settings.json`:

```json
{
    // yadda yadda
    "rust-analyzer.cargo.extraEnv": {
        "AWS_ACCESS_KEY_ID": "YOUR ID",
        "AWS_SECRET_ACCESS_KEY": "YOUR KEY",
        "AWS_REGION": "YOUR REGION",
        "AWS_S3_BUCKET": "YOUR BUCKET",
    }
}
```

Then, any tests you run from rust-analyzer's test icons overlaid in the files _should_ work.